### PR TITLE
Save hidden state across load screens

### DIFF
--- a/HideGroup.lua
+++ b/HideGroup.lua
@@ -3,23 +3,37 @@ local HG = HideGroup
 local EM = GetEventManager()
 
 HG.name = "HideGroup"
-HG.version = "1.0"
+HG.version = "1.1"
 
 local function hideMembers(enable)
 	if enable == true then
 		SetCrownCrateNPCVisible(true)
+		-- Only override if the hide state has changed. Otherwise, when they turn it off, it will load the no show options
+		if HG.savedVariables.HideState ~= enable then
+			d("Hide Group: Hiding group members")
+			HG.savedVariables.GroupMemberNameplates = GetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_NAMEPLATES)
+			HG.savedVariables.GroupMemberHealthBars = GetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_HEALTHBARS)
+		end
 		SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_NAMEPLATES, tostring(NAMEPLATE_CHOICE_NEVER))
 		SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_HEALTHBARS, tostring(NAMEPLATE_CHOICE_NEVER))
 	else
 		SetCrownCrateNPCVisible(false)
-		SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_NAMEPLATES, tostring(HG.savedVariables.GroupMemberNameplates))
-		SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_HEALTHBARS, tostring(HG.savedVariables.GroupMemberHealthBars))
+		if HG.savedVariables.HideState ~= enable then
+			d("Hide Group: Showing group members")
+			SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_NAMEPLATES, tostring(HG.savedVariables.GroupMemberNameplates))
+			SetSetting(SETTING_TYPE_NAMEPLATES, NAMEPLATE_TYPE_GROUP_MEMBER_HEALTHBARS, tostring(HG.savedVariables.GroupMemberHealthBars))
+		end
 	end
+	HG.savedVariables.HideState = enable
 end
 
 local function sCommand(opt)
 	if opt == "true" or opt == "1" then
 		hideMembers(true)
+	elseif opt == "false" or opt == "0" then
+		hideMembers(false)
+	elseif opt == nil or opt == "" then
+		hideMembers(not HG.savedVariables.HideState)
 	else
 		hideMembers(false)
 	end
@@ -34,6 +48,12 @@ function HG.init(e, addon)
 	}
 	HG.savedVariables = ZO_SavedVars:New("HideGroupSavedVars", 1, nil, HG.defaults, GetWorldName())
 	SLASH_COMMANDS["/hidegroup"] = sCommand
+	EM:RegisterForEvent(HG.name.."PlayerActivated", EVENT_PLAYER_ACTIVATED, function()
+		if HG.savedVariables.HideState then
+			hideMembers(HG.savedVariables.HideState)
+		end
+	end) -- For after porting
+
 end
 
 EM:RegisterForEvent(HG.name.."Load", EVENT_ADD_ON_LOADED, HG.init)

--- a/HideGroup.txt
+++ b/HideGroup.txt
@@ -1,7 +1,7 @@
 ## Title: HideGroup
 ## Description: Hides your group members
 ## Author: Wheels
-## Version: 1.0
+## Version: 1.1
 ## APIVersion: 100026
 ## SavedVariables: HideGroupSavedVars
 


### PR DESCRIPTION
- Also added better saving of nameplate choices
- Added more options for accessing the addon functionality, including making no arguments toggle the current state
- Added outputs when the user hides or shows group members